### PR TITLE
fix/#53/jwt 토큰 갱신 이슈

### DIFF
--- a/src/main/java/com/ssafy/freezetag/domain/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ssafy/freezetag/domain/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.ssafy.freezetag.domain.exception;
 import com.ssafy.freezetag.domain.exception.custom.TokenException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/src/main/java/com/ssafy/freezetag/domain/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ssafy/freezetag/domain/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.ssafy.freezetag.domain.exception;
 
+import com.ssafy.freezetag.domain.exception.custom.TokenException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -31,6 +32,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleOAuth2AuthenticationException(final OAuth2AuthenticationException e) {
         log.warn("OAuth2 authentication error: {}", e.getMessage());
         return ResponseEntity.status(401)
+                .body(new ErrorResponse(false, e.getMessage()));
+
+    }
+
+    /*
+        토큰 관련 에러
+     */
+    @ExceptionHandler(TokenException.class)
+    public ResponseEntity<ErrorResponse> handleTokenException(final TokenException e) {
+        log.warn("Token error: {}", e.getMessage());
+        return ResponseEntity.status(400)
                 .body(new ErrorResponse(false, e.getMessage()));
 
     }

--- a/src/main/java/com/ssafy/freezetag/domain/exception/custom/OpenviduTokenException.java
+++ b/src/main/java/com/ssafy/freezetag/domain/exception/custom/OpenviduTokenException.java
@@ -1,4 +1,4 @@
-package com.ssafy.freezetag.global.exception;
+package com.ssafy.freezetag.domain.exception.custom;
 
 public class OpenviduTokenException extends RuntimeException{
     public OpenviduTokenException() {

--- a/src/main/java/com/ssafy/freezetag/domain/exception/custom/TokenException.java
+++ b/src/main/java/com/ssafy/freezetag/domain/exception/custom/TokenException.java
@@ -1,9 +1,8 @@
 package com.ssafy.freezetag.domain.exception.custom;
 
-public class TokenException extends RuntimeException {
+public class    TokenException extends RuntimeException {
 
-    private String errorCode;
     public TokenException(String errorCode) {
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 }

--- a/src/main/java/com/ssafy/freezetag/domain/exception/custom/TokenException.java
+++ b/src/main/java/com/ssafy/freezetag/domain/exception/custom/TokenException.java
@@ -1,4 +1,4 @@
-package com.ssafy.freezetag.global.exception;
+package com.ssafy.freezetag.domain.exception.custom;
 
 public class TokenException extends RuntimeException {
 

--- a/src/main/java/com/ssafy/freezetag/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.ssafy.freezetag.domain.member.controller;
+
+import com.ssafy.freezetag.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+@Slf4j
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestParam String providerId) {
+
+        // 우선 정상적인 provider인지 확인하고 리디렉션 URL을 가져옴
+        // TODO : redirectUrl 관리하는 법 처리
+        String redirectUrl = memberService.checkProvider(providerId);
+        log.info("redirect url : {}", redirectUrl);
+
+        // oauth url로 redirect 처리
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header("Location", redirectUrl)
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/ssafy/freezetag/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/controller/MemberController.java
@@ -1,6 +1,9 @@
 package com.ssafy.freezetag.domain.member.controller;
 
 import com.ssafy.freezetag.domain.member.service.MemberService;
+import com.ssafy.freezetag.domain.oauth2.service.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final TokenService tokenService;
 
     @PostMapping("/login")
     public ResponseEntity<Void> login(@RequestParam String providerId) {
@@ -27,6 +31,35 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.FOUND)
                 .header("Location", redirectUrl)
                 .build();
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+        // 현재 로그인 인증정보 확인
+        memberService.checkAuthentication(request);
+
+        // 로그아웃 후 세션 무효화 및 쿠키 삭제
+        memberService.deleteTokenAndSession(request, response);
+
+        // 응답 JSON 객체 생성
+        var responseBody = new MemberController.ResponseBody(true);
+
+        // 응답 반환
+        return ResponseEntity.ok()
+                .body(responseBody);
+    }
+
+    // 응답 바디를 위한 내부 클래스
+    private static class ResponseBody {
+        private final boolean success;
+
+        public ResponseBody(boolean success) {
+            this.success = success;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
     }
 }
 

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
@@ -1,9 +1,25 @@
 package com.ssafy.freezetag.domain.member.service;
 
+import com.ssafy.freezetag.domain.exception.custom.TokenException;
+import com.ssafy.freezetag.domain.oauth2.TokenProvider;
+import com.ssafy.freezetag.domain.oauth2.entity.Token;
+import com.ssafy.freezetag.domain.oauth2.service.TokenService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final TokenProvider tokenProvider;
+    private final TokenService tokenService;
 
     public String checkProvider(String providerId) {
 
@@ -18,5 +34,83 @@ public class MemberService {
         }
 
         throw new RuntimeException("올바른 provider가 아닙니다.");
+    }
+
+    /*
+        로그아웃 => token redis에서 삭제
+     */
+    // TODO : OAuth2Controller과 겹친 부분 utils로 빼기
+    public void checkAuthentication(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        // 쿠키가 아예 존재하지 않나 확인
+        if(cookies == null) {
+            throw new TokenException("쿠키가 존재하지 않습니다.");
+        }
+
+        // 쿠키 조회
+        String refreshToken = getRefreshToken(cookies);
+        if(!StringUtils.hasText(refreshToken)) {
+            throw new TokenException("Refresh Token이 존재하지 않습니다.");
+        }
+
+        // accessToken 조회
+        String accessToken = request.getHeader("Authorization");
+//
+//
+//        // 인증 정보 확인
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new RuntimeException("현재 사용자의 인증 정보 오류가 발생하였습니다.");
+        }
+
+        String memberId = authentication.getName();
+        // 그리고 access, refresh간 id 불일치 발생하면 처리
+        if(!tokenProvider.validateSameTokens(accessToken, refreshToken)) {
+            throw new TokenException("Access Token과 Refresh Token 사용자 정보 불일치합니다.");
+        }
+
+        System.out.println(memberId);
+        // 현재 시큐리티 세션의 id랑 accessToken 불일치 발생하면 오류
+        if(!tokenProvider.getAuthentication((accessToken)).getName().equals(memberId)) {
+            throw new TokenException("유저와 사용자 정보가 불일치합니다.");
+        }
+        // 레디스에서 정보 삭제
+        tokenService.deleteRefreshToken(memberId);
+
+    }
+
+    /*
+        레디스의 refreshToken, 세션 정보 삭제
+     */
+    public void deleteTokenAndSession(HttpServletRequest request, HttpServletResponse response) {
+        // 로그아웃 후 세션 무효화 및 쿠키 삭제
+        request.getSession().invalidate();
+
+        // refreshToken 쿠키 삭제
+        Cookie refreshTokenCookie = new Cookie("refreshToken", null);
+        refreshTokenCookie.setMaxAge(0); // 쿠키의 유효 기간을 0으로 설정하여 삭제
+        refreshTokenCookie.setPath("/"); // 쿠키가 유효한 경로 설정
+        response.addCookie(refreshTokenCookie);
+
+        // 세션 쿠키 삭제
+        Cookie sessionCookie = new Cookie("JSESSIONID", null);
+        sessionCookie.setPath("/"); // 쿠키의 유효 경로 설정
+        sessionCookie.setMaxAge(0); // 쿠키의 유효 기간을 0으로 설정하여 삭제
+        response.addCookie(sessionCookie);
+    }
+
+    /*
+    쿠키에서 refreshToken 찾아주는 코드
+ */
+    public String getRefreshToken(Cookie[] cookies) {
+        String refreshToken = "";
+        for (Cookie cookie : cookies) {
+            if ("refreshToken".equals(cookie.getName())) {
+                refreshToken = cookie.getValue();
+                break;
+            }
+        }
+        return refreshToken;
     }
 }

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
@@ -45,7 +45,7 @@ public class MemberService {
 
         // 쿠키가 아예 존재하지 않나 확인
         if(cookies == null) {
-            throw new TokenException("쿠키가 존재하지 않습니다.");
+            throw new RuntimeException("쿠키가 존재하지 않습니다.");
         }
 
         // 쿠키 조회
@@ -70,7 +70,6 @@ public class MemberService {
             throw new TokenException("Access Token과 Refresh Token 사용자 정보 불일치합니다.");
         }
 
-        System.out.println(memberId);
         // 현재 시큐리티 세션의 id랑 accessToken 불일치 발생하면 오류
         if(!tokenProvider.getAuthentication((accessToken)).getName().equals(memberId)) {
             throw new TokenException("유저와 사용자 정보가 불일치합니다.");

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
@@ -1,0 +1,22 @@
+package com.ssafy.freezetag.domain.member.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+    public String checkProvider(String providerId) {
+
+        // provider id가 null이거나, providerId가 비었을 경우
+        if (providerId == null || providerId.isEmpty()) {
+            throw new RuntimeException("provider 값이 존재하지 않습니다.");
+        }
+
+        // 현재 어플리케이션에서 지원하는 provider인지 분기
+        if (providerId.equals("kakao")) {
+            return "/oauth2/authorization/kakao";
+        }
+
+        throw new RuntimeException("올바른 provider가 아닙니다.");
+    }
+}

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/response/LoginResponseDto.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/response/LoginResponseDto.java
@@ -1,0 +1,10 @@
+package com.ssafy.freezetag.domain.member.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDto {
+    private String memberName;
+}

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenAuthenticationFilter.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -19,6 +20,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;
@@ -30,17 +32,28 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
         // accessToken 검증
         if (tokenProvider.validateToken(accessToken)) {
+            log.info("AccessToken is valid!!");
             setAuthentication(accessToken); // 토큰이 유효하므로 인증 정보 설정
         } else {
-            // 만료되었을 경우 accessToken 재발급
-            String reissueAccessToken = tokenProvider.reissueAccessToken(accessToken);
+            log.info("AccessToken not valid");
+            // 우선 userId를 AccessToken으로 추출
 
-            if (StringUtils.hasText(reissueAccessToken)) {
-                setAuthentication(reissueAccessToken);
 
-                // 재발급된 accessToken 다시 전달
-                response.setHeader(AUTHORIZATION, TokenKey.TOKEN_PREFIX + reissueAccessToken);
+            if (StringUtils.hasText(accessToken)) {
+                String memberId = tokenProvider.getAuthentication(accessToken).getName();
+                log.info("memberId : {}", memberId);
+                // 만료되었을 경우 accessToken 재발급
+                String reissueAccessToken = tokenProvider.reissueAccessToken(memberId);
+                log.info("reissueAccessToken : {}", reissueAccessToken);
+                if (StringUtils.hasText(reissueAccessToken)) {
+                    setAuthentication(reissueAccessToken);
+
+                    // 재발급된 accessToken 다시 전달
+                    response.setHeader(AUTHORIZATION, TokenKey.TOKEN_PREFIX + reissueAccessToken);
+                }
             }
+
+
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
@@ -1,7 +1,6 @@
 package com.ssafy.freezetag.domain.oauth2;
 
 import com.ssafy.freezetag.domain.exception.custom.TokenException;
-import com.ssafy.freezetag.domain.oauth2.entity.Token;
 import com.ssafy.freezetag.domain.oauth2.service.TokenService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -108,8 +107,19 @@ public class TokenProvider {
         }
 
         Claims claims = parseClaims(token);
-        // 토큰의 만료 여부 확인하는 코
+        // 토큰의 만료 여부 확인하는 코드
         return claims.getExpiration().after(new Date());
+    }
+
+    /*
+        access와 refresh token의 id가 정말 같은지 확인
+     */
+    public boolean validateSameTokens(String accessToken, String refreshToken) {
+        if (!validateToken(accessToken) || !validateToken(refreshToken)) {
+            return false;
+        }
+        return getAuthentication(accessToken).getName()
+                .equals(getAuthentication(refreshToken).getName());
     }
 
     private Claims parseClaims(String token) {

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
@@ -1,6 +1,7 @@
 package com.ssafy.freezetag.domain.oauth2;
 
 import com.ssafy.freezetag.domain.exception.custom.TokenException;
+import com.ssafy.freezetag.domain.oauth2.entity.Token;
 import com.ssafy.freezetag.domain.oauth2.service.TokenService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -107,6 +108,7 @@ public class TokenProvider {
         }
 
         Claims claims = parseClaims(token);
+        // 토큰의 만료 여부 확인하는 코
         return claims.getExpiration().after(new Date());
     }
 
@@ -115,11 +117,11 @@ public class TokenProvider {
             return Jwts.parser().verifyWith(secretKey).build()
                     .parseSignedClaims(token).getPayload();
         } catch (ExpiredJwtException e) {
-            return e.getClaims();
+            throw new TokenException("Access Token이 만료되었습니다.");
         } catch (MalformedJwtException e) {
-            throw new TokenException("INVALID_TOKEN");
+            throw new TokenException("Access Token 형식이 잘못되었습니다.");
         } catch (SecurityException e) {
-            throw new TokenException("INVALID_JWT_SIGNATURE");
+            throw new TokenException("Access Token이 손상되었습니다.");
         }
     }
 }

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
@@ -35,10 +35,8 @@ public class TokenProvider {
     @Value("${jwt.key}")
     private String key;
     private SecretKey secretKey;
-//    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L; // 30 minutes
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 3L; // 1분
-    //    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7 days
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 5L;
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60L; // 1시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7L; // 7일
     private static final String KEY_ROLE = "role";
     private final TokenService tokenService;
 
@@ -64,8 +62,6 @@ public class TokenProvider {
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining());
 
-        log.info("authentication.getName() : {}", authentication.getName());
-
         return Jwts.builder()
                 .subject(authentication.getName())
                 .claim(KEY_ROLE, authorities)
@@ -88,13 +84,17 @@ public class TokenProvider {
                 claims.get(KEY_ROLE).toString()));
     }
 
-    public String reissueAccessToken(String refreshToken) {
-        if (StringUtils.hasText(refreshToken)) {
-            Token token = tokenService.findByRefreshTokenOrThrow(refreshToken);
+    public String reissueAccessToken(String memberId) {
+        // 만약 memberId가 존재한다면
+        if (StringUtils.hasText(memberId)) {
+            String refreshToken = tokenService.findByIdOrThrow(memberId).getRefreshToken();
 
+            // 정상적인 refreshToken이다면
+            // 만약 이미 만료된 accessToken으로 접근한다고 해도=> refreshToken이 없다면 => refreshToken 생성 안함!
             if (validateToken(refreshToken)) {
+                // 다시 accessToken재발급해줌
                 String reissueAccessToken = generateAccessToken(getAuthentication(refreshToken));
-                tokenService.saveOrUpdate(token.getId(), refreshToken); // refreshToken은 갱신하지 않음
+                tokenService.saveOrUpdate(memberId, refreshToken);
                 return reissueAccessToken;
             }
         }

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
@@ -1,7 +1,6 @@
 package com.ssafy.freezetag.domain.oauth2;
 
-import com.ssafy.freezetag.global.exception.TokenException;
-import com.ssafy.freezetag.domain.oauth2.entity.Token;
+import com.ssafy.freezetag.domain.exception.custom.TokenException;
 import com.ssafy.freezetag.domain.oauth2.service.TokenService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -49,9 +48,10 @@ public class TokenProvider {
         return generateToken(authentication, ACCESS_TOKEN_EXPIRE_TIME);
     }
 
-    public void generateRefreshToken(Authentication authentication) {
+    public String generateRefreshToken(Authentication authentication) {
         String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRE_TIME);
         tokenService.saveOrUpdate(authentication.getName(), refreshToken);
+        return refreshToken;
     }
 
     private String generateToken(Authentication authentication, long expireTime) {

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/controller/OAuth2Controller.java
@@ -1,0 +1,62 @@
+package com.ssafy.freezetag.domain.oauth2.controller;
+
+import com.ssafy.freezetag.domain.oauth2.service.OAuth2Service;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oauth")
+public class OAuth2Controller {
+
+    private final OAuth2Service oAuth2Service;
+
+    @GetMapping("/reissue-tokens")
+    public ResponseEntity<?> reissueAllToken(HttpServletRequest request, HttpServletResponse response) {
+        List<String> tokenList = oAuth2Service.reissueAllTokens(request);
+
+        // 토큰을 리스트에서 추출
+        String accessToken = tokenList.get(0);
+        String refreshToken = tokenList.get(1);
+
+        // accessToken을 HTTP 헤더에 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        // refreshToken을 HTTP Only 쿠키로 설정
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true); // HTTPS에서만 사용 가능하도록 설정
+        refreshTokenCookie.setPath("/"); // 쿠키가 유효한 경로 설정
+        response.addCookie(refreshTokenCookie);
+
+        // 응답 JSON 객체 생성
+        var responseBody = new ResponseBody(true);
+
+        // 응답 반환
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(responseBody);
+    }
+
+    // 응답 바디를 위한 내부 클래스
+    private static class ResponseBody {
+        private final boolean success;
+
+        public ResponseBody(boolean success) {
+            this.success = success;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+    }
+}

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/handler/OAuth2SuccessHandler.java
@@ -32,7 +32,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         cookie.setHttpOnly(true); // 쿠키를 HTTP-only로 설정
         cookie.setSecure(true); // HTTPS에서만 쿠키를 전송하도록 설정
         cookie.setPath("/"); // 쿠키의 유효 범위를 설정
-        cookie.setMaxAge(60); // 쿠키의 유효 기간 설정 (지금은 1시간)
+        cookie.setMaxAge(3600); // 쿠키의 유효 기간 설정 (지금은 1시간)
 
         // 쿠키를 응답에 추가
         response.addCookie(cookie);

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,34 +1,46 @@
 package com.ssafy.freezetag.domain.oauth2.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.freezetag.domain.member.service.response.LoginResponseDto;
 import com.ssafy.freezetag.domain.oauth2.TokenProvider;
+import com.ssafy.freezetag.domain.oauth2.service.OAuthAttributesDto;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
+
+import static com.ssafy.freezetag.domain.common.constant.TokenKey.TOKEN_PREFIX;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final TokenProvider tokenProvider;
-    private static final String URI = "/";
+    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 직렬화를 위한 ObjectMapper
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
         // accessToken, refreshToken 발급
         String accessToken = tokenProvider.generateAccessToken(authentication);
-        // refreshToken 생성 후 redis에 저장
-        tokenProvider.generateRefreshToken(authentication);
+        String refreshToken = tokenProvider.generateRefreshToken(authentication);
 
-        // HTTP-only 쿠키로 accessToken 설정
-        Cookie cookie = new Cookie("accessToken", accessToken);
+        // AccessToken 첨부
+        response.addHeader("Authorization", TOKEN_PREFIX + accessToken);
+
+        // HTTP-only 쿠키에 refreshToken 첨부
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
         cookie.setHttpOnly(true); // 쿠키를 HTTP-only로 설정
         cookie.setSecure(true); // HTTPS에서만 쿠키를 전송하도록 설정
         cookie.setPath("/"); // 쿠키의 유효 범위를 설정
@@ -37,8 +49,31 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         // 쿠키를 응답에 추가
         response.addCookie(cookie);
 
-        // 토큰 전달을 위한 redirect
-        String redirectUrl = UriComponentsBuilder.fromUriString(URI).build().toUriString();
-        response.sendRedirect(redirectUrl);
+        // 응답 상태 코드를 201 Created로 설정
+        response.setStatus(HttpServletResponse.SC_CREATED);
+
+        // 응답 본문에 JSON 형태로 토큰 정보를 포함
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        
+        // TODO : 이름 수정
+        // LoginResponseDto 생성
+        LoginResponseDto loginResponseDto = new LoginResponseDto(authentication.getName());
+
+        // Result 객체 생성
+        Result<LoginResponseDto> result = new Result<>(true, loginResponseDto);
+
+        // JSON 형태로 변환
+        String jsonResponse = objectMapper.writeValueAsString(result);
+
+        // 응답에 JSON 작성
+        response.getWriter().write(jsonResponse);
+    }
+
+    @Data
+    @AllArgsConstructor
+    static class Result<T> {
+        private boolean success;
+        private T data;
     }
 }

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/handler/OAuth2SuccessHandler.java
@@ -16,6 +16,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -58,7 +59,16 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         
         // TODO : 이름 수정
         // LoginResponseDto 생성
-        LoginResponseDto loginResponseDto = new LoginResponseDto(authentication.getName());
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // 'properties' 객체에서 'nickname'을 가져오는 과정
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        String memberName = (String) properties.get("nickname");
+
+        LoginResponseDto loginResponseDto = new LoginResponseDto(memberName);
 
         // Result 객체 생성
         Result<LoginResponseDto> result = new Result<>(true, loginResponseDto);

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/service/OAuth2Service.java
@@ -1,0 +1,67 @@
+package com.ssafy.freezetag.domain.oauth2.service;
+
+import com.ssafy.freezetag.domain.exception.custom.TokenException;
+import com.ssafy.freezetag.domain.oauth2.TokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2Service {
+
+    private final TokenProvider tokenProvider;
+
+    /*
+        refreshToken으로 accessToken 재발급 후 refreshToken 갱신 메소드
+     */
+    public List<String> reissueAllTokens(HttpServletRequest request) {
+        List<String> tokenList = new ArrayList<>();
+        String accessToken;
+        String refreshToken;
+        Cookie[] cookies = request.getCookies();
+
+        // 쿠키가 아예 존재하지 않나 확인
+        if(cookies == null) {
+            throw new TokenException("쿠키가 존재하지 않습니다.");
+        }
+
+        // 쿠키 조회
+        refreshToken = getRefreshToken(cookies);
+        if(!StringUtils.hasText(refreshToken)) {
+            throw new TokenException("Refresh Token이 존재하지 않습니다.");
+        }
+
+        // Token 유효성 검증
+        tokenProvider.validateToken(refreshToken);
+
+        // memberId 추출
+        Authentication authentication = tokenProvider.getAuthentication(refreshToken);
+        String memberId = authentication.getName();
+        accessToken = tokenProvider.reissueAccessToken(memberId);
+        refreshToken = tokenProvider.generateRefreshToken(authentication);
+
+        tokenList.add(accessToken);
+        tokenList.add(refreshToken);
+        return tokenList;
+    }
+
+    /*
+        쿠키에서 refreshToken 찾아주는 코드
+     */
+    public String getRefreshToken(Cookie[] cookies) {
+        String refreshToken = "";
+        for (Cookie cookie : cookies) {
+            if ("refreshToken".equals(cookie.getName())) {
+                refreshToken = cookie.getValue();
+                break;
+            }
+        }
+        return refreshToken;
+    }
+}

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/service/TokenService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/service/TokenService.java
@@ -1,6 +1,6 @@
 package com.ssafy.freezetag.domain.oauth2.service;
 //
-//import com.ssafy.freezetag.global.exception.TokenException;
+//import com.ssafy.freezetag.domain.exception.custom.TokenException;
 //import com.ssafy.freezetag.domain.oauth2.entity.Token;
 //import com.ssafy.freezetag.domain.oauth2.repository.TokenRepository;
 //import jakarta.transaction.Transactional;
@@ -40,7 +40,7 @@ package com.ssafy.freezetag.domain.oauth2.service;
 //    }
 //}
 
-import com.ssafy.freezetag.global.exception.TokenException;
+import com.ssafy.freezetag.domain.exception.custom.TokenException;
 import com.ssafy.freezetag.domain.oauth2.entity.Token;
 import com.ssafy.freezetag.domain.oauth2.repository.TokenRepository;
 import jakarta.transaction.Transactional;

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/service/TokenService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/service/TokenService.java
@@ -59,6 +59,9 @@ public class TokenService {
         tokenRepository.deleteById(memberKey);
     }
 
+    /*
+        refreshToken update
+     */
     @Transactional
     public void saveOrUpdate(String memberKey, String refreshToken) {
         Token token = tokenRepository.findById(memberKey)
@@ -68,8 +71,11 @@ public class TokenService {
         tokenRepository.save(token);
     }
 
-    public Token findByRefreshTokenOrThrow(String refreshToken) {
-        return tokenRepository.findByRefreshToken(refreshToken)
+    /*
+        memberId를 활용해서 refreshToken 찾는 것
+     */
+    public Token findByIdOrThrow(String memberKey) {
+        return tokenRepository.findById(memberKey)
                 .orElseThrow(() -> new TokenException("TOKEN_EXPIRED"));
     }
 }

--- a/src/main/java/com/ssafy/freezetag/domain/room/service/OpenviduService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/room/service/OpenviduService.java
@@ -1,7 +1,7 @@
 package com.ssafy.freezetag.domain.room.service;
 
 import com.ssafy.freezetag.domain.room.service.request.OpenviduResponseDto;
-import com.ssafy.freezetag.global.exception.OpenviduTokenException;
+import com.ssafy.freezetag.domain.exception.custom.OpenviduTokenException;
 import io.openvidu.java.client.*;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
@@ -51,22 +51,22 @@ public class SecurityConfig {
                                 )
                                 .successHandler(oAuth2SuccessHandler)
                 )
-                .logout(logout ->
-                        logout
-                                .logoutUrl("/logout") // 로그아웃 요청 URL
-                                .logoutSuccessUrl("/")
-                                .invalidateHttpSession(true)
-                                .deleteCookies("JSESSIONID")
-                                .addLogoutHandler(new LogoutHandler() { // 익명 클래스
-                                    @Override
-                                    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-                                        if (authentication != null) {
-                                            String username = authentication.getName();
-                                            tokenService.deleteRefreshToken(username); // Redis에서 토큰 삭제
-                                        }
-                                    }
-                                })
-                )
+//                .logout(logout ->
+//                        logout
+//                                .logoutUrl("/logout") // 로그아웃 요청 URL
+//                                .logoutSuccessUrl("/")
+//                                .invalidateHttpSession(true)
+//                                .deleteCookies("JSESSIONID")
+//                                .addLogoutHandler(new LogoutHandler() { // 익명 클래스
+//                                    @Override
+//                                    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+//                                        if (authentication != null) {
+//                                            String username = authentication.getName();
+//                                            tokenService.deleteRefreshToken(username); // Redis에서 토큰 삭제
+//                                        }
+//                                    }
+//                                })
+//                )
                 .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new TokenExceptionFilter(), tokenAuthenticationFilter.getClass()) // 토큰 예외 핸들링
         ;

--- a/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
@@ -1,10 +1,11 @@
 package com.ssafy.freezetag.global.config;
 
-import com.ssafy.freezetag.global.filter.TokenExceptionFilter;
+//import com.ssafy.freezetag.global.filter.TokenExceptionFilter;
 import com.ssafy.freezetag.domain.oauth2.handler.OAuth2SuccessHandler;
 import com.ssafy.freezetag.domain.oauth2.service.CustomOAuth2UserService;
 import com.ssafy.freezetag.global.filter.TokenAuthenticationFilter;
 import com.ssafy.freezetag.domain.oauth2.service.TokenService;
+import com.ssafy.freezetag.global.filter.TokenExceptionFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
@@ -51,22 +51,6 @@ public class SecurityConfig {
                                 )
                                 .successHandler(oAuth2SuccessHandler)
                 )
-//                .logout(logout ->
-//                        logout
-//                                .logoutUrl("/logout") // 로그아웃 요청 URL
-//                                .logoutSuccessUrl("/")
-//                                .invalidateHttpSession(true)
-//                                .deleteCookies("JSESSIONID")
-//                                .addLogoutHandler(new LogoutHandler() { // 익명 클래스
-//                                    @Override
-//                                    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-//                                        if (authentication != null) {
-//                                            String username = authentication.getName();
-//                                            tokenService.deleteRefreshToken(username); // Redis에서 토큰 삭제
-//                                        }
-//                                    }
-//                                })
-//                )
                 .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new TokenExceptionFilter(), tokenAuthenticationFilter.getClass()) // 토큰 예외 핸들링
         ;

--- a/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
@@ -1,9 +1,9 @@
 package com.ssafy.freezetag.global.config;
 
-import com.ssafy.freezetag.domain.oauth2.TokenExceptionFilter;
+import com.ssafy.freezetag.global.filter.TokenExceptionFilter;
 import com.ssafy.freezetag.domain.oauth2.handler.OAuth2SuccessHandler;
 import com.ssafy.freezetag.domain.oauth2.service.CustomOAuth2UserService;
-import com.ssafy.freezetag.domain.oauth2.TokenAuthenticationFilter;
+import com.ssafy.freezetag.global.filter.TokenAuthenticationFilter;
 import com.ssafy.freezetag.domain.oauth2.service.TokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/ssafy/freezetag/global/controller/HomeController.java
+++ b/src/main/java/com/ssafy/freezetag/global/controller/HomeController.java
@@ -16,7 +16,6 @@ public class HomeController {
     public String homePage(Model model) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated()) {
-            System.out.println(authentication);
 
             if (authentication.getPrincipal() instanceof OAuth2User) {
                 OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
@@ -3,7 +3,7 @@ package com.ssafy.freezetag.global.filter;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.ssafy.freezetag.domain.common.constant.TokenKey;
-리import com.ssafy.freezetag.domain.oauth2.TokenProvider;
+import com.ssafy.freezetag.domain.oauth2.TokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
@@ -34,43 +34,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             log.info("AccessToken is valid!!");
             setAuthentication(accessToken); // 토큰이 유효하므로 인증 정보 설정
         }
-
-
-            // 401 Exception 발생
-
-
-
-        // 2. accessToken이 이상이 있을 경우
-        // 2.1 401에러를 통해서 refreshToken
-
-        //        String accessToken = resolveToken(request);
-//
-//        // accessToken 검증
-//        if (tokenProvider.validateToken(accessToken)) {
-//            log.info("AccessToken is valid!!");
-//            setAuthentication(accessToken); // 토큰이 유효하므로 인증 정보 설정
-//        } else {
-//            log.info("AccessToken not valid");
-//
-//            if (StringUtils.hasText(accessToken)) {
-//                String memberId = tokenProvider.getAuthentication(accessToken).getName();
-//                log.info("memberId : {}", memberId);
-//                // 만료되었을 경우 accessToken 재발급
-//                String reissueAccessToken = tokenProvider.reissueAccessToken(memberId);
-//                log.info("reissueAccessToken : {}", reissueAccessToken);
-//                if (StringUtils.hasText(reissueAccessToken)) {
-//                    setAuthentication(reissueAccessToken);
-//
-//                    // 재발급된 accessToken을 HttpOnly 쿠키로 전달
-//                    Cookie cookie = new Cookie("accessToken", reissueAccessToken);
-//                    cookie.setHttpOnly(true);
-//                    cookie.setSecure(true); // HTTPS에서만 사용 가능하도록 설정
-//                    cookie.setPath("/"); // 쿠키가 유효한 경로 설정
-//                    response.addCookie(cookie);
-//                }
-//            }
-//        }
-//
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.ssafy.freezetag.global.filter;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.ssafy.freezetag.domain.common.constant.TokenKey;
+import com.ssafy.freezetag.domain.exception.custom.TokenException;
 import com.ssafy.freezetag.domain.oauth2.TokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -29,7 +30,29 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-//        String accessToken = resolveToken(request);
+        String accessToken = resolveToken(request);
+        log.info("accesstoken: {}", accessToken);
+        // 1. 우선 filter을 통해 accessToken에 이상이 없을 경우
+        if (tokenProvider.validateToken(accessToken)) {
+            log.info("AccessToken is valid!!");
+            setAuthentication(accessToken); // 토큰이 유효하므로 인증 정보 설정
+        } else {
+            // 2. accesstoken에 이상 있을 경우
+            // 우선 에러 발생
+            if (StringUtils.hasText(accessToken)) {
+                log.info("adf");
+                throw new TokenException("Access Token이 유효하지 않습니다.");
+            }
+        }
+
+            // 401 Exception 발생
+
+
+
+        // 2. accessToken이 이상이 있을 경우
+        // 2.1 401에러를 통해서 refreshToken
+
+        //        String accessToken = resolveToken(request);
 //
 //        // accessToken 검증
 //        if (tokenProvider.validateToken(accessToken)) {
@@ -60,6 +83,9 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /*
+        인증정보 설정하는 메소드
+     */
     private void setAuthentication(String accessToken) {
         Authentication authentication = tokenProvider.getAuthentication(accessToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
@@ -3,11 +3,9 @@ package com.ssafy.freezetag.global.filter;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.ssafy.freezetag.domain.common.constant.TokenKey;
-import com.ssafy.freezetag.domain.exception.custom.TokenException;
-import com.ssafy.freezetag.domain.oauth2.TokenProvider;
+리import com.ssafy.freezetag.domain.oauth2.TokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -17,7 +15,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
@@ -36,14 +33,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         if (tokenProvider.validateToken(accessToken)) {
             log.info("AccessToken is valid!!");
             setAuthentication(accessToken); // 토큰이 유효하므로 인증 정보 설정
-        } else {
-            // 2. accesstoken에 이상 있을 경우
-            // 우선 에러 발생
-            if (StringUtils.hasText(accessToken)) {
-                log.info("adf");
-                throw new TokenException("Access Token이 유효하지 않습니다.");
-            }
         }
+
 
             // 401 Exception 발생
 

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.ssafy.freezetag.domain.oauth2;
+package com.ssafy.freezetag.global.filter;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
@@ -29,34 +29,34 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String accessToken = resolveToken(request);
-
-        // accessToken 검증
-        if (tokenProvider.validateToken(accessToken)) {
-            log.info("AccessToken is valid!!");
-            setAuthentication(accessToken); // 토큰이 유효하므로 인증 정보 설정
-        } else {
-            log.info("AccessToken not valid");
-
-            if (StringUtils.hasText(accessToken)) {
-                String memberId = tokenProvider.getAuthentication(accessToken).getName();
-                log.info("memberId : {}", memberId);
-                // 만료되었을 경우 accessToken 재발급
-                String reissueAccessToken = tokenProvider.reissueAccessToken(memberId);
-                log.info("reissueAccessToken : {}", reissueAccessToken);
-                if (StringUtils.hasText(reissueAccessToken)) {
-                    setAuthentication(reissueAccessToken);
-
-                    // 재발급된 accessToken을 HttpOnly 쿠키로 전달
-                    Cookie cookie = new Cookie("accessToken", reissueAccessToken);
-                    cookie.setHttpOnly(true);
-                    cookie.setSecure(true); // HTTPS에서만 사용 가능하도록 설정
-                    cookie.setPath("/"); // 쿠키가 유효한 경로 설정
-                    response.addCookie(cookie);
-                }
-            }
-        }
-
+//        String accessToken = resolveToken(request);
+//
+//        // accessToken 검증
+//        if (tokenProvider.validateToken(accessToken)) {
+//            log.info("AccessToken is valid!!");
+//            setAuthentication(accessToken); // 토큰이 유효하므로 인증 정보 설정
+//        } else {
+//            log.info("AccessToken not valid");
+//
+//            if (StringUtils.hasText(accessToken)) {
+//                String memberId = tokenProvider.getAuthentication(accessToken).getName();
+//                log.info("memberId : {}", memberId);
+//                // 만료되었을 경우 accessToken 재발급
+//                String reissueAccessToken = tokenProvider.reissueAccessToken(memberId);
+//                log.info("reissueAccessToken : {}", reissueAccessToken);
+//                if (StringUtils.hasText(reissueAccessToken)) {
+//                    setAuthentication(reissueAccessToken);
+//
+//                    // 재발급된 accessToken을 HttpOnly 쿠키로 전달
+//                    Cookie cookie = new Cookie("accessToken", reissueAccessToken);
+//                    cookie.setHttpOnly(true);
+//                    cookie.setSecure(true); // HTTPS에서만 사용 가능하도록 설정
+//                    cookie.setPath("/"); // 쿠키가 유효한 경로 설정
+//                    response.addCookie(cookie);
+//                }
+//            }
+//        }
+//
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenExceptionFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenExceptionFilter.java
@@ -1,6 +1,6 @@
-package com.ssafy.freezetag.domain.oauth2;
+package com.ssafy.freezetag.global.filter;
 
-import com.ssafy.freezetag.global.exception.TokenException;
+import com.ssafy.freezetag.domain.exception.custom.TokenException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenExceptionFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenExceptionFilter.java
@@ -1,5 +1,7 @@
 package com.ssafy.freezetag.global.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.freezetag.domain.exception.ErrorResponse;
 import com.ssafy.freezetag.domain.exception.custom.TokenException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -10,6 +12,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 public class TokenExceptionFilter extends OncePerRequestFilter {
 
+    private final ObjectMapper objectMapper = new ObjectMapper(); // Jackson ObjectMapper
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
@@ -17,7 +21,16 @@ public class TokenExceptionFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (TokenException e) {
-            response.sendError(401, e.getMessage());
+            handleTokenException(response, e);
         }
     }
+
+    private void handleTokenException(HttpServletResponse response, TokenException e) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 상태 코드
+        response.setContentType("application/json");
+        ErrorResponse errorResponse = new ErrorResponse(false, e.getMessage());
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonResponse);
+    }
+
 }

--- a/src/main/resources/application-oauth.properties
+++ b/src/main/resources/application-oauth.properties
@@ -1,6 +1,6 @@
 # ??? KAKAO OAuth ??
 # TODO : config??? ??
-spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize?prompt=login
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
 spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -9,7 +9,9 @@
     <h1>Welcome!</h1>
     {{#nickname}}
         <p>You are logged in as {{nickname}}.</p>
-        <a href="/logout" class="btn btn-secondary">Logout</a>
+        <form action="/member/logout" method="POST">
+        <button type="submit" class="btn btn-secondary active">logout</button>
+        </form>
     {{/nickname}}
     {{^nickname}}
         <p>You are not logged in.</p>

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -13,7 +13,10 @@
     {{/nickname}}
     {{^nickname}}
         <p>You are not logged in.</p>
-        <a href="/oauth2/authorization/kakao" class="btn btn-secondary active" role="button">Kakao Login</a>
-    {{/nickname}}
+        <form action="/member/login" method="POST">
+            <input type="hidden" name="providerId" value="kakao">
+            <button type="submit" class="btn btn-secondary active">Kakao Login</button>
+        </form>
+        {{/nickname}}
 </body>
 </html>


### PR DESCRIPTION
# 제목
fix: #53 accessToken 발급 완료
### 이슈 번호 : # 53

## 변경 사항
- accessToken 성공적으로 갱신 및 httpOnly 쿠키에 성공적으로 전송
- refreshToken은 만료가 되면 해당 토큰은 재발급하지 않음(보안상 재로그인) - [참고](https://www.inflearn.com/community/questions/1223854/refresh-token-%EC%9E%AC%EB%B0%9C%EA%B8%89%EA%B3%BC-%EB%A7%8C%EB%A3%8C%EC%97%90-%EB%8C%80%ED%95%B4%EC%84%9C)
- 과정
  - `doFilterInternal` 애서 accessToken 존재 처리. 먼저 accessToken이 존재할 경우에 `tokenProvider.reissueAccessToken(memberId)` 호출
  - 해당 메소드에서는 redis에 refreshToken이 유효한지 확인
    - **확인하는 이유** : 만약에 refreshToken이 유효하지 않는데(존재하지 않거나, 변조되었거나) accessToken을 재발급할 수 있다면 보안문제 발생 가능
    - 혹시라도 refreshToken 유효하지 않다면 null 반환해서 filterChain탈 수 있도록 함
    - 유효하다면 accessToken 재발급 후 httpOnly 쿠키로 전달
  - accessToken이 존재하지 않는다면 그대로 filterChain타고 익명상태로 서비스 이용

## 그 외
- 중복 수정 : `OAuth2SuccessHandler`와 `TokenAuthenticationFilter`에서 쿠키값 보내는 기능이 중복 => 후에 리팩토링 해야 하는데 어떻게 처리?
- `tokenProvider.reissueAccessToken` 메소드에서 `memberId` 존재하는지 확인하는 로직이`doFilterInternal`에서 memberId를 추출하는데 굳이 필요할까? 후에 refactoring 대상

## 결과
- 새로운 accessToken 발급 및 cookie에 전달되는 것 확인
![image](https://github.com/user-attachments/assets/0c980b09-bc18-4ba5-a80f-fcd1ff2bfbca)

![image](https://github.com/user-attachments/assets/c48b9775-1ca1-4427-92b2-4e0b4ac1e5fd)

## 질문 사항
- 
