### PR TITLE
deploy: #73 refreshToken을 redis에 저장하지 않음

### DIFF
--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/TokenProvider.java
@@ -52,7 +52,7 @@ public class TokenProvider {
     public String generateRefreshToken(Authentication authentication) {
         Long memberId = getMemberId(authentication);
         String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRE_TIME, memberId);
-        tokenService.saveOrUpdate(memberId.toString(), refreshToken);
+//        tokenService.saveOrUpdate(memberId.toString(), refreshToken);
         return refreshToken;
     }
 


### PR DESCRIPTION
# 제목
deploy: #73 refreshToken을 redis에 저장하지 않음
### 이슈 번호 : #73

## 변경 사항
-    refreshToken 임시로 저장 x

## 그 외
- 

## 질문 사항
- 
