### PR TITLE
fix/#95/Redis-포트-변경-오류-수정

### DIFF
--- a/src/main/java/com/ssafy/freezetag/global/config/RedisConfig.java
+++ b/src/main/java/com/ssafy/freezetag/global/config/RedisConfig.java
@@ -2,6 +2,7 @@ package com.ssafy.freezetag.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
@@ -14,7 +15,10 @@ public class RedisConfig {
 
     @Bean
     public LettuceConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory();
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName("redis");
+        redisStandaloneConfiguration.setPort(6380);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
     @Bean


### PR DESCRIPTION
# 제목
fix: redis 호스트 및 포트 입력
### 이슈 번호 : #95 

## 변경 사항
-   RedisConfig의  redisConnectionFactory에 hostname과 port를 할당해주었습니다.

## 그 외
- 너무 힘들었습니다..

## 질문 사항
- 
