### PR TITLE
Fix/#117/로그인 안되는 오류(401) 수정

### DIFF
--- a/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
+    private final TokenExceptionFilter tokenExceptionFilter;
     private final TokenService tokenService; // 추가
 
     @Bean
@@ -45,7 +46,7 @@ public class SecurityConfig {
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new TokenExceptionFilter(), TokenAuthenticationFilter.class); // 수정됨
+                .addFilterBefore(tokenExceptionFilter, TokenAuthenticationFilter.class); // 수정됨
 
         return http.build();
     }

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         String requestURI = request.getRequestURI();
-        if (requestURI.equals("/oauth/login")) {
+        if (requestURI.equals("/api/oauth/login")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenExceptionFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenExceptionFilter.java
@@ -7,13 +7,17 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@RequiredArgsConstructor
+@Component
 public class TokenExceptionFilter extends OncePerRequestFilter {
 
-    private final ObjectMapper objectMapper = new ObjectMapper(); // Jackson ObjectMapper
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,


### PR DESCRIPTION
requestURI 필터 내에서 추가로 수정해줘야 함

# 제목
fix: #117 TokenAuthenticationFilter 수정

### 이슈 번호 : #117

## 변경 사항
- TokenAuthenticationFilter 내 `requestURI.equals("/api/oauth/login")` 로 수정해줘야 함 (기존 = `/oauth/login`)

## 그 외
- `permitAll()`이 만능은 아닙니다
  - 해당 요청에 대한 접근 권한을 허용하는 설정이지, 필터 체인 자체를 변경하거나 짧은 경로로 처리하는 것은 아님
  - 즉 => 특정 filter가 존재하면 항상 요청이 들어올 때마다 순서대로 호출되는것. `permitAll()` 에 uri가 박혀있다고 해서 필터 통과면제하는 것은 아님
  - FilterChain 및 SecurityConfig 헷갈리실 분을 위해서 짧게 정리했습니다.
- [참고글1](https://stackoverflow.com/questions/76084548/spring-boot-permitall-not-working-using-securityfilterchain)
- [참고글2](https://velog.io/@choidongkuen/Spring-Security-SecurityConfig-%ED%81%B4%EB%9E%98%EC%8A%A4%EC%9D%98-permitAll-%EC%9D%B4-%EC%A0%81%EC%9A%A9%EB%90%98%EC%A7%80-%EC%95%8A%EC%95%98%EB%8D%98-%EC%9D%B4%EC%9C%A0)

## 참고사항
- 현재 FilterChain 순서 및 작동방식은 다음과 같음
- `tokenExceptionFilter` => `TokenAuthenticationFilter` => `UsernamePasswordAuthenticationFilter`(이 필터는 oauth에서는 필요없긴 한데 나중에 폼 기반 로그인 할 수 있으니 넣음)
1. `tokenExceptionFilter` 에서는 직전의 필터에서 발생한 Exception 예외처리 로직  
   - 여기서는 try ~ catch문을 통해 다음 필터에서의 에러를 탐지.
   - 우선 `filterChain.doFilter(request, response)`를 통해 다음 필터로 넘긴다
   - 필터 체인을 타면서 아무 에러가 catch되지 않을 경우 무사히 통과하게 된다.
2. `tokenAuthenticationFilter`에서 인증
   - `/api/oauth/login`인 uri일 경우에는 다음 필터로 넘어가도록 한다. => 즉 아무 예외상황이 발생하지 않으므로 `tokenExceptionFilter`에서 예외처리 및 401 에러를 반환하지 않아도 된다.
   - 그렇지 않으면 필터 내 `resolveToken()`(**Access Token이 없다는 에러는 여기서 발생한다**) 에서 토큰 존재여부 확인 및 `setAuthentication()`에서 토큰 유효성 검증을 해서 오류가 생기면 `TokenException`이 발생 => 
   - 현재 필터 체인을 타고 있기 때문에 tokenExceptionFilter에서는 catch문을 통해 `handleTokenException`을 실행시켜 예외상황 처리




## 질문 사항
- 현재 다른 부분은 건드리지 않고 딱 `/api/oauth/login`만 수정하긴 했는데 혹시 401 Access Token 없다는 에러 뜨면 이거 참고해서 잘 처리해보시길
- 여기도 나중에 uri 교통정리 필요할듯
