### PR TITLE
refactor : #136 security, token필터에 경로 수정

### DIFF
--- a/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
                                 .requestMatchers("/", "api/home", "api/login", "/css/**", "/images/**", "/js/**",
-                                        "/h2-console/**", "api/profile", "api/public/**", "api/login/**", "api/oauth/login", "websocket/**",
+                                        "/h2-console/**", "api/profile", "api/public/**", "api/login/**", "api/oauth/login", "/api/websocket/**",
                                         "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/freezetag/global/filter/TokenAuthenticationFilter.java
@@ -1,7 +1,5 @@
 package com.ssafy.freezetag.global.filter;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
 import com.ssafy.freezetag.domain.common.constant.TokenKey;
 import com.ssafy.freezetag.domain.exception.custom.TokenException;
 import com.ssafy.freezetag.domain.oauth2.TokenProvider;
@@ -9,10 +7,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -20,6 +14,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @RequiredArgsConstructor
 @Component
@@ -42,7 +42,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             "/api/public",
             "/api/login",
             "/api/home",
-            "/websocket"
+            "/api/websocket"
     );
 
     @Override


### PR DESCRIPTION
# 제목
security, token필터에 경로 수정
### 이슈 번호 : #136 

## 변경 사항
- 웹소켓 및 messagemapping에 prefix 경로 api 추가로 security 및 토큰필터에 허용 경로 수정

## 그 외
- 

## 질문 사항
- 
