### PR TITLE
fix: #175 : SecurityConfig에 S3 도메인 등록 - / 제거

### DIFF
--- a/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/freezetag/global/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                 "http://localhost:3000",
                 "http://localhost:5173",
                 "https://i11c209.p.ssafy.io",
-                "https://sarrr.s3.ap-northeast-2.amazonaws.com/"
+                "https://sarrr.s3.ap-northeast-2.amazonaws.com"
         ));
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");


### PR DESCRIPTION
# 제목
fix: #175 : SecurityConfig에 S3 도메인 등록 - / 제거
### 이슈 번호 : #175 

## 변경 사항
-     SecurityConfig에 S3 도메인 등록 - / 제거

## 그 외
- 

## 질문 사항
- 
