### PR TITLE
Feat/#180/방 나가기 로직 구현

### DIFF
--- a/src/main/java/com/ssafy/freezetag/domain/room/controller/RoomController.java
+++ b/src/main/java/com/ssafy/freezetag/domain/room/controller/RoomController.java
@@ -33,8 +33,8 @@ public class RoomController implements RoomControllerSwagger{
         return ResponseEntity.ok(success(responseDto));
     }
 
-    @DeleteMapping("/exit")
-    public ResponseEntity<?> enterRoom(@Login Long memberId, @RequestParam Long roomId) {
+    @DeleteMapping("/{roomId}/exit")
+    public ResponseEntity<?> enterRoom(@Login Long memberId, @PathVariable Long roomId) {
         roomService.exitRoom(roomId, memberId);
         return ResponseEntity.noContent()
                 .build();
@@ -47,5 +47,6 @@ public class RoomController implements RoomControllerSwagger{
         return ResponseEntity.ok()
                 .body(success(roomReport));
     }
+
 
 }

--- a/src/main/java/com/ssafy/freezetag/domain/room/controller/RoomControllerSwagger.java
+++ b/src/main/java/com/ssafy/freezetag/domain/room/controller/RoomControllerSwagger.java
@@ -30,6 +30,14 @@ public interface RoomControllerSwagger {
     @PostMapping("/enter")
     ResponseEntity<?> enterRoom(@Login Long memberId, @RequestParam String roomCode) throws JsonProcessingException;
 
+    @Operation(summary = "방 중도 퇴장")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "방 퇴장 완료", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "500", description = "방 퇴장 실패", content = @Content(mediaType = "application/json"))
+    })
+    @DeleteMapping("/{roomId}/exit")
+    ResponseEntity<?> enterRoom(@Login Long memberId, @PathVariable Long roomId);
+
     @Operation(summary = "방 결과 레포트 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "방 결과 레포트 조회 성공", content = @Content(mediaType = "application/json")),

--- a/src/main/java/com/ssafy/freezetag/domain/room/entity/RoomRedis.java
+++ b/src/main/java/com/ssafy/freezetag/domain/room/entity/RoomRedis.java
@@ -7,7 +7,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @Getter
-@RedisHash(value = "room")
+@RedisHash(value = "room", timeToLive = 3600)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RoomRedis {
     @Id

--- a/src/main/java/com/ssafy/freezetag/domain/room/service/RoomService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/room/service/RoomService.java
@@ -95,16 +95,12 @@ public class RoomService {
         // Redis에 세션 및 방 정보 저장
         roomRedisService.saveRoomInfo(enterCode, webrtcDto.getSessionId(), room.getId());
 
-        // Redis에서 채팅(메세지) 정보 불러오기
-        List<MessageRedis> messages = messageService.getMessages(room.getId());
-
         return createRoomConnectResponseDto(
                 room,
                 enterCode,
                 dto.getRoomName(),
                 dto.getRoomPersonCount(),
-                webrtcDto,
-                messages
+                webrtcDto
         );
 
     }
@@ -140,17 +136,13 @@ public class RoomService {
         // OpenVidu 토큰 반환
         OpenviduResponseDto webrtcDto = openviduService.enterRoom(sessionId, member);
 
-        // Redis에서 채팅(메세지) 정보 불러오기
-        List<MessageRedis> messages = messageService.getMessages(roomId);
-
         // 현재 방 정보 반환
         return createRoomConnectResponseDto(
                 fetchJoinedRoom,
                 enterCode,
                 fetchJoinedRoom.getRoomName(),
                 fetchJoinedRoom.getRoomPersonCount(),
-                webrtcDto,
-                messages
+                webrtcDto
         );
 
     }

--- a/src/main/java/com/ssafy/freezetag/domain/room/service/helper/RoomConverter.java
+++ b/src/main/java/com/ssafy/freezetag/domain/room/service/helper/RoomConverter.java
@@ -16,15 +16,14 @@ public class RoomConverter {
                 .toList();
     }
 
-    public static RoomConnectResponseDto createRoomConnectResponseDto(Room room, String enterCode, String roomName, int roomPersonCount, OpenviduResponseDto webrtcDto, List<MessageRedis> messages) {
+    public static RoomConnectResponseDto createRoomConnectResponseDto(Room room, String enterCode, String roomName, int roomPersonCount, OpenviduResponseDto webrtcDto) {
         return new RoomConnectResponseDto(
                 room.getId(),
                 enterCode,
                 roomName,
                 roomPersonCount,
                 room.getHost().getId(),
-                webrtcDto,
-                messages
+                webrtcDto
         );
     }
 }

--- a/src/main/java/com/ssafy/freezetag/domain/room/service/response/RoomConnectResponseDto.java
+++ b/src/main/java/com/ssafy/freezetag/domain/room/service/response/RoomConnectResponseDto.java
@@ -17,5 +17,4 @@ public class RoomConnectResponseDto {
     private Integer roomPersonCount;
     private Long hostId;
     private OpenviduResponseDto webrtc;
-    private List<MessageRedis> messages;
 }


### PR DESCRIPTION
# 제목
Feat/#180/방 나가기 로직 구현
### 이슈 번호 : #180

## 변경 사항
-  방 컨트롤러의 "방 나가기" 에 스웨거 적용
- RoomRedis에 TTL 적용 (1시간)
- 채팅 내역을 ResponseDTO에서 삭제
- exit 엔드포인트에 PathVariable 적용

## 그 외
- 

## 질문 사항
- 
