### PR TITLE
fix : #189 ResponseWrapperAspect 로직 변경

### DIFF
--- a/src/main/java/com/ssafy/freezetag/domain/common/aspect/ResponseWrapperAspect.java
+++ b/src/main/java/com/ssafy/freezetag/domain/common/aspect/ResponseWrapperAspect.java
@@ -40,7 +40,7 @@ public class ResponseWrapperAspect {
                     .headers(headers)
                     .body(CommonResponse.success(responseBody));
         }
-        throw new IllegalStateException("controller 반환 값은 항상 ResponseEntity 를 사용해주세요");
+        return result;
     }
 
 }

--- a/src/main/java/com/ssafy/freezetag/domain/room/controller/RoomControllerSwagger.java
+++ b/src/main/java/com/ssafy/freezetag/domain/room/controller/RoomControllerSwagger.java
@@ -33,7 +33,7 @@ public interface RoomControllerSwagger {
     @Operation(summary = "방 중도 퇴장")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "방 퇴장 완료", content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "500", description = "방 퇴장 실패", content = @Content(mediaType = "application/json"))
+            @ApiResponse(responseCode = "404", description = "퇴장할 해당 회원이 없음", content = @Content(mediaType = "application/json"))
     })
     @DeleteMapping("/{roomId}/exit")
     ResponseEntity<?> enterRoom(@Login Long memberId, @PathVariable Long roomId);


### PR DESCRIPTION
# 제목
fix : #189 ResponseWrapperAspect 로직 변경
### 이슈 번호 : #189

## 변경 사항
- 소켓 통신은 ResponseEntity를 사용하지 않기 때문에 예외를 발생시킴
- 이를 그냥 리턴하는 방식으로 수정함

## 그 외
- 

## 질문 사항
- 
