### PR TITLE
Feat/#203/구글 OAuth 연결

### DIFF
--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/controller/OAuth2Controller.java
@@ -61,8 +61,12 @@ public class OAuth2Controller {
         // 'properties' 객체에서 'nickname'을 가져오는 과정
         @SuppressWarnings("unchecked")
         Map<String, Object> properties = (Map<String, Object>) oAuth2User.getAttributes().get("properties");
-        String memberName = (String) properties.get("nickname");
-
+        String memberName;
+        if (properties == null) {
+            memberName = (String) oAuth2User.getAttributes().get("name");
+        } else {
+            memberName = (String) properties.get("nickname");
+        }
 
         Long memberId = tokenProvider.getMemberId(authentication);
         Member member = memberService.findMember(memberId);
@@ -74,10 +78,10 @@ public class OAuth2Controller {
 
         // LoginResponseDto 생성
         LoginResponseDto loginResponseDto = new LoginResponseDto(
-                                                    memberName,
-                                                    memberId,
-                                                    memberProviderEmail,
-                                                    memberProfileImageUrl);
+                memberName,
+                memberId,
+                memberProviderEmail,
+                memberProfileImageUrl);
 
         // 응답 반환
         return ResponseEntity.ok()

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/service/OAuth2Service.java
@@ -7,12 +7,14 @@ import com.ssafy.freezetag.domain.oauth2.TokenProvider;
 import com.ssafy.freezetag.domain.oauth2.entity.CustomOAuth2User;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -55,7 +57,24 @@ public class OAuth2Service {
                 .queryParam("client_secret", clientRegistration.getClientSecret());
         System.out.println(uriBuilder.toUriString());
         // Make the request and extract the access token from the response
-        Map<String, String> response = restTemplate.postForObject(uriBuilder.toUriString(), null, Map.class);
+        // Set headers
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // Create HttpEntity
+        HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+
+        System.out.println(uriBuilder.toUriString());
+
+        // Make the request and extract the access token from the response
+        ResponseEntity<Map> responseEntity = restTemplate.exchange(
+                uriBuilder.toUriString(),
+                HttpMethod.POST,
+                requestEntity,
+                Map.class
+        );
+        Map<String, String> response = responseEntity.getBody();
+
         String accessToken = response.get("access_token");
 
         if (accessToken == null) {
@@ -72,9 +91,23 @@ public class OAuth2Service {
         }
 
         String userInfoEndpointUri = clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri();
+        System.out.println(userInfoEndpointUri);
 
         RestTemplate restTemplate = new RestTemplate();
-        Map<String, Object> userAttributes = restTemplate.getForObject(userInfoEndpointUri + "?access_token=" + accessToken, Map.class);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder
+                .fromUriString(userInfoEndpointUri)
+                .queryParam("access_token", accessToken);
+
+        System.out.println(uriBuilder.toUriString());
+        ResponseEntity<Map> responseEntity = restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, entity, Map.class);
+        Map<String, Object> userAttributes = responseEntity.getBody();
+
+//        Map<String, Object> userAttributes = restTemplate.getForObject(userInfoEndpointUri + "?access_token=" + accessToken, Map.class);
 
         if (userAttributes == null) {
             throw new RuntimeException("Failed to retrieve user info");
@@ -90,7 +123,6 @@ public class OAuth2Service {
         );
 
         OAuthAttributesDto attributes = OAuthAttributesDto.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
-
 
 
         // 저장
@@ -127,13 +159,13 @@ public class OAuth2Service {
         Cookie[] cookies = request.getCookies();
 
         // 쿠키가 아예 존재하지 않나 확인
-        if(cookies == null) {
+        if (cookies == null) {
             throw new TokenException("쿠키가 존재하지 않습니다.");
         }
 
         // 쿠키 조회
         refreshToken = getRefreshToken(cookies);
-        if(!StringUtils.hasText(refreshToken)) {
+        if (!StringUtils.hasText(refreshToken)) {
             throw new TokenException("Refresh Token이 존재하지 않습니다.");
         }
 

--- a/src/main/java/com/ssafy/freezetag/domain/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/ssafy/freezetag/domain/oauth2/service/OAuth2Service.java
@@ -7,13 +7,8 @@ import com.ssafy.freezetag.domain.oauth2.TokenProvider;
 import com.ssafy.freezetag.domain.oauth2.entity.CustomOAuth2User;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -26,8 +21,14 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OAuth2Service {
 
     private final ClientRegistrationRepository clientRegistrationRepository;
@@ -55,7 +56,7 @@ public class OAuth2Service {
                 .queryParam("redirect_uri", clientRegistration.getRedirectUri())
                 .queryParam("client_id", clientRegistration.getClientId())
                 .queryParam("client_secret", clientRegistration.getClientSecret());
-        System.out.println(uriBuilder.toUriString());
+
         // Make the request and extract the access token from the response
         // Set headers
         HttpHeaders headers = new HttpHeaders();
@@ -64,7 +65,7 @@ public class OAuth2Service {
         // Create HttpEntity
         HttpEntity<String> requestEntity = new HttpEntity<>(headers);
 
-        System.out.println(uriBuilder.toUriString());
+        log.info("uriBuilder.toString() = {}", uriBuilder.toUriString());
 
         // Make the request and extract the access token from the response
         ResponseEntity<Map> responseEntity = restTemplate.exchange(
@@ -103,7 +104,7 @@ public class OAuth2Service {
                 .fromUriString(userInfoEndpointUri)
                 .queryParam("access_token", accessToken);
 
-        System.out.println(uriBuilder.toUriString());
+        log.info("uriBuilder.toString() = {}", uriBuilder.toUriString());
         ResponseEntity<Map> responseEntity = restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, entity, Map.class);
         Map<String, Object> userAttributes = responseEntity.getBody();
 

--- a/src/main/resources/application-oauth.properties
+++ b/src/main/resources/application-oauth.properties
@@ -12,3 +12,8 @@ spring.security.oauth2.client.registration.kakao.redirect-uri=https://i11c209.p.
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.kakao.client-name=kakao
 spring.security.oauth2.client.registration.kakao.scope=profile_nickname, profile_image, account_email
+
+spring.security.oauth2.client.registration.google.client-id=525008052920-7q5qrrg047jk5qcfg9eg5krthhbea13o.apps.googleusercontent.com
+spring.security.oauth2.client.registration.google.client-secret=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
+spring.security.oauth2.client.registration.google.scope=profile,email
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:5173/login/oauth2/code/google


### PR DESCRIPTION
# 제목
Feat/#203/구글 OAuth 연결
### 이슈 번호 : #203 

## 변경 사항
- 구글 OAuth 키 프로퍼티에 추가
- 카카오 응답값과 구글 응답값 분기 처리
- OAuth 요청에 헤더 추가 (구글은 해줘야함)

## 그 외
- OAuthController에서 응답값 구조가 달라서 null 체크해서 분기하고 있긴 한데 너무 짜쳐요
- 리팩터링 필수일 것 같습니다 

## 질문 사항
- 
