### PR TITLE
Feat/#227/마이페이지 다른 사람 프로필 조회

### DIFF
--- a/src/main/java/com/ssafy/freezetag/domain/exception/custom/MemberNotPublicException.java
+++ b/src/main/java/com/ssafy/freezetag/domain/exception/custom/MemberNotPublicException.java
@@ -1,0 +1,8 @@
+package com.ssafy.freezetag.domain.exception.custom;
+
+public class MemberNotPublicException extends RuntimeException{
+
+    public MemberNotPublicException(String errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ssafy/freezetag/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import com.ssafy.freezetag.domain.member.service.response.MemberHistoryDto;
 import com.ssafy.freezetag.domain.member.service.response.MemberMemoryboxDto;
 import com.ssafy.freezetag.domain.member.service.response.MypageResponseDto;
 import com.ssafy.freezetag.domain.member.service.response.MypageVisibilityResponseDto;
+import com.ssafy.freezetag.domain.member.service.response.ProfileResponseDto;
 import com.ssafy.freezetag.domain.oauth2.service.TokenService;
 import com.ssafy.freezetag.global.argumentresolver.Login;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,7 +29,7 @@ import static com.ssafy.freezetag.domain.common.CommonResponse.success;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/member")
+@RequestMapping("/api")
 @Slf4j
 public class MemberController {
     private final ObjectMapper objectMapper;
@@ -36,7 +37,7 @@ public class MemberController {
     private final TokenService tokenService;
     private final MemberRepository memberRepository;
 
-    @GetMapping("/mypage")
+    @GetMapping("/member/mypage")
     public ResponseEntity<?> mypage(@Login Long memberId) {
 
         MypageResponseDto mypageResponseDto = memberService.getMypage(memberId);
@@ -69,7 +70,7 @@ public class MemberController {
                 .build();
     }
 
-    @PutMapping("/mypage/visibility")
+    @PutMapping("/member/mypage/visibility")
     public ResponseEntity<?> visibility(@Login Long memberId, @RequestBody MypageVisibilityRequestDto requestDto) {
         Visibility requestVisibility = requestDto.getVisibility();
         MypageVisibilityResponseDto mypageVisibilityResponseDto = memberService.setMypageVisibility(memberId, requestVisibility);
@@ -77,7 +78,7 @@ public class MemberController {
                 .body(success(mypageVisibilityResponseDto));
     }
 
-    @PostMapping("/logout")
+    @PostMapping("/member/logout")
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
         // 현재 로그인 인증정보 확인
         memberService.checkAuthentication(request);
@@ -89,6 +90,17 @@ public class MemberController {
         return ResponseEntity.noContent()
                 .build();
     }
+
+    @GetMapping("member/profile/{memberId}")
+    public ResponseEntity<?> profile(@PathVariable Long memberId) {
+        // 다른 사람의 memberId를 통해서 프로필 조회하는 코드
+        ProfileResponseDto profileResponseDto = memberService.getProfile(memberId);
+        // 반환
+        return ResponseEntity.ok()
+                .body(success(profileResponseDto));
+    }
+
+
 }
 
 

--- a/src/main/java/com/ssafy/freezetag/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/controller/MemberController.java
@@ -29,7 +29,7 @@ import static com.ssafy.freezetag.domain.common.CommonResponse.success;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/member")
 @Slf4j
 public class MemberController {
     private final ObjectMapper objectMapper;
@@ -37,7 +37,7 @@ public class MemberController {
     private final TokenService tokenService;
     private final MemberRepository memberRepository;
 
-    @GetMapping("/member/mypage")
+    @GetMapping("/mypage")
     public ResponseEntity<?> mypage(@Login Long memberId) {
 
         MypageResponseDto mypageResponseDto = memberService.getMypage(memberId);
@@ -70,7 +70,7 @@ public class MemberController {
                 .build();
     }
 
-    @PutMapping("/member/mypage/visibility")
+    @PutMapping("/mypage/visibility")
     public ResponseEntity<?> visibility(@Login Long memberId, @RequestBody MypageVisibilityRequestDto requestDto) {
         Visibility requestVisibility = requestDto.getVisibility();
         MypageVisibilityResponseDto mypageVisibilityResponseDto = memberService.setMypageVisibility(memberId, requestVisibility);
@@ -78,7 +78,7 @@ public class MemberController {
                 .body(success(mypageVisibilityResponseDto));
     }
 
-    @PostMapping("/member/logout")
+    @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
         // 현재 로그인 인증정보 확인
         memberService.checkAuthentication(request);
@@ -91,7 +91,7 @@ public class MemberController {
                 .build();
     }
 
-    @GetMapping("member/profile/{memberId}")
+    @GetMapping("/{memberId}")
     public ResponseEntity<?> profile(@PathVariable Long memberId) {
         // 다른 사람의 memberId를 통해서 프로필 조회하는 코드
         ProfileResponseDto profileResponseDto = memberService.getProfile(memberId);

--- a/src/main/java/com/ssafy/freezetag/domain/member/repository/MemberHistoryRepository.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/repository/MemberHistoryRepository.java
@@ -16,12 +16,4 @@ public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Lo
             "WHERE m.id = :memberId")
     Member findMemberWithHistories(Long memberId);
 
-
-//    // history가 없을 수도 있으므로 RIGHT JOIN 해야 함
-//    @Query("SELECT mh " +
-//            "FROM MemberHistory mh " +
-//            "RIGHT JOIN FETCH mh.member m " +
-//            "WHERE m.id = :memberId")
-//    List<MemberHistory> findAllByMemberIdWithFetchJoinHistory(Long memberId);
-
 }

--- a/src/main/java/com/ssafy/freezetag/domain/member/repository/MemberHistoryRepository.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/repository/MemberHistoryRepository.java
@@ -3,6 +3,7 @@ package com.ssafy.freezetag.domain.member.repository;
 import com.ssafy.freezetag.domain.member.entity.Member;
 import com.ssafy.freezetag.domain.member.entity.MemberHistory;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +15,6 @@ public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Lo
     @Query("SELECT m FROM Member m " +
             "LEFT JOIN FETCH m.memberHistories mh " +
             "WHERE m.id = :memberId")
-    Member findMemberWithHistories(Long memberId);
+    Optional<Member> findMemberWithHistories(Long memberId);
 
 }

--- a/src/main/java/com/ssafy/freezetag/domain/member/repository/MemberHistoryRepository.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/repository/MemberHistoryRepository.java
@@ -1,11 +1,27 @@
 package com.ssafy.freezetag.domain.member.repository;
 
+import com.ssafy.freezetag.domain.member.entity.Member;
 import com.ssafy.freezetag.domain.member.entity.MemberHistory;
 import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Long> {
     @EntityGraph(attributePaths = {"member"})
     List<MemberHistory> findByMemberId(Long memberId);
+
+    @Query("SELECT m FROM Member m " +
+            "LEFT JOIN FETCH m.memberHistories mh " +
+            "WHERE m.id = :memberId")
+    Member findMemberWithHistories(Long memberId);
+
+
+//    // history가 없을 수도 있으므로 RIGHT JOIN 해야 함
+//    @Query("SELECT mh " +
+//            "FROM MemberHistory mh " +
+//            "RIGHT JOIN FETCH mh.member m " +
+//            "WHERE m.id = :memberId")
+//    List<MemberHistory> findAllByMemberIdWithFetchJoinHistory(Long memberId);
+
 }

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
@@ -62,11 +62,9 @@ public class MemberService {
         memberId를 통해서 ResponseDto 생성
      */
     public MypageResponseDto getMypage(Long memberId) {
-        Member member = memberHistoryRepository.findMemberWithHistories(memberId);
-        // 멤버 없을 시 예외처리
-        if(member == null) {
-            throw new MemberNotFoundException("회원이 존재하지 않습니다.");
-        }
+        Member member = memberHistoryRepository.findMemberWithHistories(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("회원이 존재하지 않습니다."));
+
         log.info("member: {}", member.toString());
         List<MemberHistory> memberHistories = member.getMemberHistories();
 
@@ -225,12 +223,8 @@ public class MemberService {
      */
     public ProfileResponseDto getProfile(Long memberId) {
 
-        Member member = memberHistoryRepository.findMemberWithHistories(memberId);
-
-        // 멤버 없을 시 예외처리
-        if(member == null) {
-            throw new MemberNotFoundException("회원이 존재하지 않습니다.");
-        }
+        Member member = memberHistoryRepository.findMemberWithHistories(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("회원이 존재하지 않습니다."));
         log.info("member: {}", member.toString());
 
 

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
@@ -1,7 +1,10 @@
 package com.ssafy.freezetag.domain.member.service;
 
+import static com.ssafy.freezetag.domain.member.entity.Visibility.PRIVATE;
+
 import com.ssafy.freezetag.domain.exception.custom.InvalidMemberVisibilityException;
 import com.ssafy.freezetag.domain.exception.custom.MemberNotFoundException;
+import com.ssafy.freezetag.domain.exception.custom.MemberNotPublicException;
 import com.ssafy.freezetag.domain.exception.custom.TokenException;
 import com.ssafy.freezetag.domain.member.entity.Member;
 import com.ssafy.freezetag.domain.member.entity.MemberHistory;
@@ -13,6 +16,7 @@ import com.ssafy.freezetag.domain.member.service.response.MemberHistoryDto;
 import com.ssafy.freezetag.domain.member.service.response.MemberMemoryboxDto;
 import com.ssafy.freezetag.domain.member.service.response.MypageResponseDto;
 import com.ssafy.freezetag.domain.member.service.response.MypageVisibilityResponseDto;
+import com.ssafy.freezetag.domain.member.service.response.ProfileResponseDto;
 import com.ssafy.freezetag.domain.oauth2.TokenProvider;
 import com.ssafy.freezetag.domain.oauth2.service.TokenService;
 import com.ssafy.freezetag.domain.room.entity.MemberRoom;
@@ -55,21 +59,23 @@ public class MemberService {
     }
 
     /*
-        memberId를 통해서 ResponseDto 생성
+    연혁 찾는 부분 DTO화
      */
-    public MypageResponseDto getMypage(Long memberId) {
-        Member member = findMember(memberId);
-
-        List<MemberHistoryDto> memberHistoryList = memberHistoryRepository.findByMemberId(memberId).stream()
-                .map(history -> new MemberHistoryDto(
-                        history.getId(),
-                        history.getMemberHistoryDate(),
-                        history.getMemberHistoryContent()
-                        )).toList();
-
+    private List<MemberHistoryDto> findMemberHistoryList(Long memberId) {
+            return memberHistoryRepository.findByMemberId(memberId).stream()
+                                            .map(history -> new MemberHistoryDto(
+                                                    history.getId(),
+                                                    history.getMemberHistoryDate(),
+                                                    history.getMemberHistoryContent()
+                                                     )).toList();
+    }
+    /*
+       추억상자 찾는 법 DTO화
+     */
+    private List<MemberMemoryboxDto> findMemberMemoryboxList(Member member) {
         List<MemberRoom> memberRooms = memberRoomRepository.findAllByMemberIdWithFetchJoinRoom(member.getId());
 
-        List<MemberMemoryboxDto> memberMemoryboxList = memberRooms.stream()
+        return memberRooms.stream()
                 .map(memberRoom -> {
                     Room room = memberRoom.getRoom();
                     return new MemberMemoryboxDto(room.getId(),
@@ -77,6 +83,17 @@ public class MemberService {
                             room.getCreatedDate(),
                             room.getRoomAfterImageUrl());
                 }).toList();
+    }
+
+    /*
+        memberId를 통해서 ResponseDto 생성
+     */
+    public MypageResponseDto getMypage(Long memberId) {
+        Member member = findMember(memberId);
+
+        List<MemberHistoryDto> memberHistoryList = findMemberHistoryList(memberId);
+
+        List<MemberMemoryboxDto> memberMemoryboxList = findMemberMemoryboxList(member);
 
         return new MypageResponseDto(
                 member.getMemberName(),
@@ -229,5 +246,34 @@ public class MemberService {
             }
         }
         return refreshToken;
+    }
+
+    /*
+        memberId를 통해서 ResponseDto 생성
+     */
+    public ProfileResponseDto getProfile(Long memberId) {
+        // 우선 공개, 비공개 여부 조회
+        Member member = findMember(memberId);
+
+        // 만약 비공개라면
+        if(member.getMemberVisibility().equals(PRIVATE)) {
+            throw new MemberNotPublicException("프로필 비공개 멤버입니다.");
+        }
+        // 멤버 정보 조회
+        List<MemberHistoryDto> memberHistoryList = findMemberHistoryList(memberId);
+
+        List<MemberRoom> memberRooms = memberRoomRepository.findAllByMemberIdWithFetchJoinRoom(member.getId());
+
+        List<MemberMemoryboxDto> memberMemoryboxList = findMemberMemoryboxList(member);
+
+        // 반환
+        return new ProfileResponseDto(
+                member.getMemberName(),
+                member.getMemberProviderEmail(),
+                member.getMemberProfileImageUrl(),
+                member.getMemberIntroduction(),
+                memberHistoryList,
+                memberMemoryboxList
+        );
     }
 }

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
@@ -63,7 +63,11 @@ public class MemberService {
      */
     public MypageResponseDto getMypage(Long memberId) {
         Member member = memberHistoryRepository.findMemberWithHistories(memberId);
-        log.info("member: {}", member);
+        // 멤버 없을 시 예외처리
+        if(member == null) {
+            throw new MemberNotFoundException("회원이 존재하지 않습니다.");
+        }
+        log.info("member: {}", member.toString());
         List<MemberHistory> memberHistories = member.getMemberHistories();
 
         List<MemberRoom> memberRooms = memberRoomRepository.findAllByMemberIdWithFetchJoinRoom(memberId);
@@ -222,7 +226,14 @@ public class MemberService {
     public ProfileResponseDto getProfile(Long memberId) {
 
         Member member = memberHistoryRepository.findMemberWithHistories(memberId);
+
+        // 멤버 없을 시 예외처리
+        if(member == null) {
+            throw new MemberNotFoundException("회원이 존재하지 않습니다.");
+        }
         log.info("member: {}", member.toString());
+
+
         List<MemberHistory> memberHistories = member.getMemberHistories();
 
 

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
@@ -11,6 +11,7 @@ import com.ssafy.freezetag.domain.member.entity.MemberHistory;
 import com.ssafy.freezetag.domain.member.entity.Visibility;
 import com.ssafy.freezetag.domain.member.repository.MemberHistoryRepository;
 import com.ssafy.freezetag.domain.member.repository.MemberRepository;
+import com.ssafy.freezetag.domain.member.service.helper.MemberConverter;
 import com.ssafy.freezetag.domain.member.service.request.MypageModifyRequestDto;
 import com.ssafy.freezetag.domain.member.service.response.MemberHistoryDto;
 import com.ssafy.freezetag.domain.member.service.response.MemberMemoryboxDto;
@@ -20,7 +21,6 @@ import com.ssafy.freezetag.domain.member.service.response.ProfileResponseDto;
 import com.ssafy.freezetag.domain.oauth2.TokenProvider;
 import com.ssafy.freezetag.domain.oauth2.service.TokenService;
 import com.ssafy.freezetag.domain.room.entity.MemberRoom;
-import com.ssafy.freezetag.domain.room.entity.Room;
 import com.ssafy.freezetag.domain.room.repository.MemberRoomRepository;
 import com.ssafy.freezetag.global.s3.S3UploadService;
 import jakarta.servlet.http.Cookie;
@@ -59,50 +59,18 @@ public class MemberService {
     }
 
     /*
-    연혁 찾는 부분 DTO화
-     */
-    private List<MemberHistoryDto> findMemberHistoryList(Long memberId) {
-            return memberHistoryRepository.findByMemberId(memberId).stream()
-                                            .map(history -> new MemberHistoryDto(
-                                                    history.getId(),
-                                                    history.getMemberHistoryDate(),
-                                                    history.getMemberHistoryContent()
-                                                     )).toList();
-    }
-    /*
-       추억상자 찾는 법 DTO화
-     */
-    private List<MemberMemoryboxDto> findMemberMemoryboxList(Member member) {
-        List<MemberRoom> memberRooms = memberRoomRepository.findAllByMemberIdWithFetchJoinRoom(member.getId());
-
-        return memberRooms.stream()
-                .map(memberRoom -> {
-                    Room room = memberRoom.getRoom();
-                    return new MemberMemoryboxDto(room.getId(),
-                            room.getRoomName(),
-                            room.getCreatedDate(),
-                            room.getRoomAfterImageUrl());
-                }).toList();
-    }
-
-    /*
         memberId를 통해서 ResponseDto 생성
      */
     public MypageResponseDto getMypage(Long memberId) {
-        Member member = findMember(memberId);
+        Member member = memberHistoryRepository.findMemberWithHistories(memberId);
+        log.info("member: {}", member);
+        List<MemberHistory> memberHistories = member.getMemberHistories();
 
-        List<MemberHistoryDto> memberHistoryList = findMemberHistoryList(memberId);
-
-        List<MemberMemoryboxDto> memberMemoryboxList = findMemberMemoryboxList(member);
-
-        return new MypageResponseDto(
-                member.getMemberName(),
-                member.getMemberVisibility(),
-                member.getMemberProviderEmail(),
-                member.getMemberProfileImageUrl(),
-                member.getMemberIntroduction(),
-                memberHistoryList,
-                memberMemoryboxList
+        List<MemberRoom> memberRooms = memberRoomRepository.findAllByMemberIdWithFetchJoinRoom(memberId);
+        return MemberConverter.createMypageResponseDto(
+                member,
+                memberHistories,
+                memberRooms
         );
 
     }
@@ -252,28 +220,24 @@ public class MemberService {
         memberId를 통해서 ResponseDto 생성
      */
     public ProfileResponseDto getProfile(Long memberId) {
-        // 우선 공개, 비공개 여부 조회
-        Member member = findMember(memberId);
+
+        Member member = memberHistoryRepository.findMemberWithHistories(memberId);
+        log.info("member: {}", member.toString());
+        List<MemberHistory> memberHistories = member.getMemberHistories();
+
 
         // 만약 비공개라면
         if(member.getMemberVisibility().equals(PRIVATE)) {
             throw new MemberNotPublicException("프로필 비공개 멤버입니다.");
         }
-        // 멤버 정보 조회
-        List<MemberHistoryDto> memberHistoryList = findMemberHistoryList(memberId);
 
-        List<MemberRoom> memberRooms = memberRoomRepository.findAllByMemberIdWithFetchJoinRoom(member.getId());
-
-        List<MemberMemoryboxDto> memberMemoryboxList = findMemberMemoryboxList(member);
+        List<MemberRoom> memberRooms = memberRoomRepository.findAllByMemberIdWithFetchJoinRoom(memberId);
 
         // 반환
-        return new ProfileResponseDto(
-                member.getMemberName(),
-                member.getMemberProviderEmail(),
-                member.getMemberProfileImageUrl(),
-                member.getMemberIntroduction(),
-                memberHistoryList,
-                memberMemoryboxList
+        return MemberConverter.createProfileResponseDto(
+                member,
+                memberHistories,
+                memberRooms
         );
     }
 }

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/MemberService.java
@@ -80,6 +80,7 @@ public class MemberService {
 
         return new MypageResponseDto(
                 member.getMemberName(),
+                member.getMemberVisibility(),
                 member.getMemberProviderEmail(),
                 member.getMemberProfileImageUrl(),
                 member.getMemberIntroduction(),

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/helper/MemberConverter.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/helper/MemberConverter.java
@@ -38,26 +38,32 @@ public class MemberConverter {
 
     public static MypageResponseDto createMypageResponseDto(Member member, List<MemberHistory> memberHistoryList, List<MemberRoom> memberRooms) {
 
+        // null값일 경우 빈 문자열 반환
+        String memberIntroduction = (member.getMemberIntroduction() != null) ? member.getMemberIntroduction() : "";
+
         // MypageResponseDto 생성 및 반환
         return new MypageResponseDto(
                 member.getMemberName(),
                 member.getMemberVisibility(),
                 member.getMemberProviderEmail(),
                 member.getMemberProfileImageUrl(),
-                member.getMemberIntroduction(),
+                memberIntroduction, // Use the checked or empty string here
                 convertToMemberHistoryDto(memberHistoryList),
                 convertToMemberMemoryboxDto(memberRooms)
         );
     }
 
+
     public static ProfileResponseDto createProfileResponseDto(Member member, List<MemberHistory> memberHistoryList, List<MemberRoom> memberRooms) {
+
+        String memberIntroduction = (member.getMemberIntroduction() != null) ? member.getMemberIntroduction() : "";
 
         // MypageResponseDto 생성 및 반환
         return new ProfileResponseDto(
                 member.getMemberName(),
                 member.getMemberProviderEmail(),
                 member.getMemberProfileImageUrl(),
-                member.getMemberIntroduction(),
+                memberIntroduction,
                 convertToMemberHistoryDto(memberHistoryList),
                 convertToMemberMemoryboxDto(memberRooms)
         );

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/helper/MemberConverter.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/helper/MemberConverter.java
@@ -1,0 +1,65 @@
+package com.ssafy.freezetag.domain.member.service.helper;
+
+import com.ssafy.freezetag.domain.exception.custom.MemberNotFoundException;
+import com.ssafy.freezetag.domain.member.entity.Member;
+import com.ssafy.freezetag.domain.member.entity.MemberHistory;
+import com.ssafy.freezetag.domain.member.service.response.MemberHistoryDto;
+import com.ssafy.freezetag.domain.member.service.response.MemberMemoryboxDto;
+import com.ssafy.freezetag.domain.member.service.response.MypageResponseDto;
+import com.ssafy.freezetag.domain.member.service.response.ProfileResponseDto;
+import com.ssafy.freezetag.domain.room.entity.MemberRoom;
+import com.ssafy.freezetag.domain.room.entity.Room;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MemberConverter {
+    public static List<MemberHistoryDto> convertToMemberHistoryDto(List<MemberHistory> memberHistories) {
+        return memberHistories.stream()
+                .map(memberHistory -> {
+                    return new MemberHistoryDto(
+                            memberHistory.getId(),
+                            memberHistory.getMemberHistoryDate(),
+                            memberHistory.getMemberHistoryContent());
+                }).toList();
+
+    }
+
+    public static List<MemberMemoryboxDto> convertToMemberMemoryboxDto(List<MemberRoom> memberRooms) {
+        return memberRooms.stream()
+                .map(memberRoom -> {
+                    Room room = memberRoom.getRoom();
+                    return new MemberMemoryboxDto(room.getId(),
+                            room.getRoomName(),
+                            room.getCreatedDate(),
+                            room.getRoomAfterImageUrl());
+                }).toList();
+    }
+
+    public static MypageResponseDto createMypageResponseDto(Member member, List<MemberHistory> memberHistoryList, List<MemberRoom> memberRooms) {
+
+        // MypageResponseDto 생성 및 반환
+        return new MypageResponseDto(
+                member.getMemberName(),
+                member.getMemberVisibility(),
+                member.getMemberProviderEmail(),
+                member.getMemberProfileImageUrl(),
+                member.getMemberIntroduction(),
+                convertToMemberHistoryDto(memberHistoryList),
+                convertToMemberMemoryboxDto(memberRooms)
+        );
+    }
+
+    public static ProfileResponseDto createProfileResponseDto(Member member, List<MemberHistory> memberHistoryList, List<MemberRoom> memberRooms) {
+
+        // MypageResponseDto 생성 및 반환
+        return new ProfileResponseDto(
+                member.getMemberName(),
+                member.getMemberProviderEmail(),
+                member.getMemberProfileImageUrl(),
+                member.getMemberIntroduction(),
+                convertToMemberHistoryDto(memberHistoryList),
+                convertToMemberMemoryboxDto(memberRooms)
+        );
+    }
+}

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/response/MypageResponseDto.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/response/MypageResponseDto.java
@@ -1,5 +1,6 @@
 package com.ssafy.freezetag.domain.member.service.response;
 
+import com.ssafy.freezetag.domain.member.entity.Visibility;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 public class MypageResponseDto {
     private String memberName;
+    private Visibility memberVisibility;
     private String memberProviderEmail;
     private String memberProfileImageUrl;
     private String memberIntroduction;

--- a/src/main/java/com/ssafy/freezetag/domain/member/service/response/ProfileResponseDto.java
+++ b/src/main/java/com/ssafy/freezetag/domain/member/service/response/ProfileResponseDto.java
@@ -1,0 +1,20 @@
+package com.ssafy.freezetag.domain.member.service.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfileResponseDto {
+    private String memberName;
+    private String memberProviderEmail;
+    private String memberProfileImageUrl;
+    private String memberIntroduction;
+    private List<MemberHistoryDto> memberHistoryList;
+    private List<MemberMemoryboxDto> memberMemoryboxList;
+
+}


### PR DESCRIPTION
# 제목
Feat/#227/마이페이지 다른 사람 프로필 조회
### 이슈 번호 : #227

## 변경 사항
- 다른사람 프로필 조회 기능추가 (URI : `api/member/profile/{memberId}`)
- 비공개일 시 `MemberNotPublicException` throw

## 그 외
- X

## 질문 사항
- 자기 자신에 대해 profile을 조회하면 어떻게 리다이렉트 처리해주면 될지 궁금합니다.
  - 예를 들어 로그인한 memberId가 1인 상황
  - `/api/member/mypage` 에서 자기 마이페이지 들어갈 수 있음
  - `api/member/profile/1` 로 들어가면 로직상 이상하니 자신 마이페이지로 redirect시켜주는 게 맞지 않을까 생각
  - 이때 서버 측에서 리다이렉트 걸어주는게 맞는지 아님 클라이언트에서 리다이렉트?
